### PR TITLE
Fix map() iterator issue in python3

### DIFF
--- a/stdeb/cli_runner.py
+++ b/stdeb/cli_runner.py
@@ -20,7 +20,7 @@ def runit(cmd,usage):
     if cmd not in ['sdist_dsc','bdist_deb']:
         raise ValueError('unknown command %r'%cmd)
     # process command-line options
-    bool_opts = map(translate_longopt, stdeb_cmd_bool_opts)
+    bool_opts = list(map(translate_longopt, stdeb_cmd_bool_opts))
     parser = FancyGetopt(stdeb_cmdline_opts+[
         ('help', 'h', "show detailed help message"),
         ])


### PR DESCRIPTION
In python3, the built-in map() function is returning an iterator, not a
list.
As a result, we can use the keyword "in" multiple times.
I propose to cast the result of map() into a list to fix the issue.

Signed-off-by: Arnaud Morin <arnaud.morin@corp.ovh.com>