### PR TITLE
Add an option --with-dh-virtualenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -579,6 +579,8 @@ To pass these commands to sdist_dsc when calling bdist_deb, do this::
                                        version
   --allow-virtualenv-install-location  Allow installing into
                                        /some/random/virtualenv-path
+  --with-dh-virtualenv                 Build the package using dh_virtualenv, so all dependencies
+                                       are embedded into the packages.
   --sign-results                       Use gpg to sign the resulting .dsc and
                                        .changes file
   --dist-dir (-d)                      directory to put final built

--- a/stdeb/command/common.py
+++ b/stdeb/command/common.py
@@ -31,6 +31,7 @@ class common_debian_package_command(Command):
         self.no_python3_scripts = 'False'
         self.force_x_python3_version = False
         self.allow_virtualenv_install_location = False
+        self.with_dh_virtualenv = False
         self.sign_results = False
         self.ignore_source_changes = False
 
@@ -221,5 +222,6 @@ class common_debian_package_command(Command):
             no_python3_scripts = self.no_python3_scripts,
             force_x_python3_version=self.force_x_python3_version,
             allow_virtualenv_install_location=self.allow_virtualenv_install_location,
+            with_dh_virtualenv=self.with_dh_virtualenv,
         )
         return debinfo

--- a/stdeb/util.py
+++ b/stdeb/util.py
@@ -107,6 +107,10 @@ stdeb_cmdline_opts = [
      'x-python3-version'),
     ('allow-virtualenv-install-location',None,
      'Allow installing into /some/random/virtualenv-path'),
+    ('with-dh-virtualenv',None,
+     'Use dh_virtualenv to build the package instead of python_distutils. '
+     'This is useful to embed an application with all its dependencies '
+     'and dont touch to the system libraries.'),
     ('sign-results',None,
      'Use gpg to sign the resulting .dsc and .changes file'),
     ('ignore-source-changes',None,
@@ -183,6 +187,7 @@ stdeb_cmd_bool_opts = [
     'no-backwards-compatibility',
     'force-x-python3-version',
     'allow-virtualenv-install-location',
+    'with-dh-virtualenv',
     'sign-results',
     'ignore-source-changes',
     ]
@@ -716,6 +721,7 @@ class DebianInfo:
                  no_python3_scripts = None,
                  force_x_python3_version=False,
                  allow_virtualenv_install_location=False,
+                 with_dh_virtualenv=False,
                  ):
         if cfg_files is NotGiven: raise ValueError("cfg_files must be supplied")
         if module_name is NotGiven: raise ValueError(
@@ -1131,7 +1137,12 @@ class DebianInfo:
             self.override_dh_python3 = ''
 
         sequencer_options = ['--with '+','.join(sequencer_with)]
-        sequencer_options.append('--buildsystem=python_distutils')
+
+        if with_dh_virtualenv:
+            sequencer_options.append('--with python-virtualenv')
+        else:
+            sequencer_options.append('--buildsystem=python_distutils')
+
         self.sequencer_options = ' '.join(sequencer_options)
 
         setup_env_vars = parse_vals(cfg,module_name,'Setup-Env-Vars')


### PR DESCRIPTION
This new option allow the builing of the package using dh_virtualenv.
This is very useful when you want to build a package that embed its
own dependencies and dont touch the system at all.
This is mainly designed to be used for python applications.

Signed-off-by: Arnaud Morin <arnaud.morin@corp.ovh.com>